### PR TITLE
better autotools integration for cargo

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -27,6 +27,6 @@ main_LDFLAGS = -Lembed_capi/target/debug -lembed_capi $(LIBADD_DL) $(PTHREAD_LIB
 embed_capi: embed
 
 embed embed_capi:
-	cd $@ && cargo build
+	cd $@ && $(CARGO) build
 
 .PHONY: embed embed_capi

--- a/Makefile.am
+++ b/Makefile.am
@@ -19,14 +19,18 @@ CLEANFILES =
 bin_PROGRAMS = main
 noinst_LTLIBRARIES =
 
+CARGO_MODE = release
+
 main_SOURCES = src/main.c
 main_DEPENDENCIES = embed_capi
 main_CFLAGS = $(PTHREAD_CFLAGS)
-main_LDFLAGS = -Lembed_capi/target/debug -lembed_capi $(LIBADD_DL) $(PTHREAD_LIBS) $(LIBM)
+main_LDFLAGS = -Lembed_capi/target/$(CARGO_MODE) -lembed_capi $(LIBADD_DL) $(PTHREAD_LIBS) $(LIBM)
 
-embed_capi: embed
+CARGO_ARGS = --$(CARGO_MODE)
+CARGO_CRATES = embed embed_capi
 
-embed embed_capi:
-	cd $@ && $(CARGO) build
+embed_capi_DEPS = embed
+
+include Makefile.cargo
 
 .PHONY: embed embed_capi

--- a/Makefile.cargo
+++ b/Makefile.cargo
@@ -1,0 +1,61 @@
+# Copyright (c) 2016 Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
+
+# * Input variables:
+#
+#   CARGO - The cargo tool
+#   CARGO_ARGS - Arguments to pass cargo
+#   CARGO_CRATES - List of crates that should be built
+#
+# * Simple tutorial
+#
+# Add this to configure.ac:
+#
+#   AX_REQUIRE_CARGO
+#
+# Add this to the Makefile.am where your crate is built:
+#
+#    include Makefile.cargo
+#    CARGO_CRATES = YourCrate
+#    YourCrate_FEATURES = foo bar
+#    YourCrate_DEPS = AnotherCrate
+
+# Ensure CARGO is defined
+$(if $(CARGO), , $(error CARGO needs to be defined))
+
+# Private functions
+## Sanitize the crate name
+_crate_name = $(subst /, _, $(subst ., _, $(subst -, _, $(1))))
+
+## Handle Makefile verbosity
+_cargo_silent_prefix = $(_cargo_silent_prefix_$(V))
+_cargo_silent_prefix_ = $(_cargo_silent_prefix_$(AM_DEFAULT_VERBOSITY))
+_cargo_silent_prefix_0 = @echo "  CARGO  $(1)";
+_cargo_silent_args = $(_cargo_silent_args_$(V))
+_cargo_silent_args_ = $(_cargo_silent_args_$(AM_DEFAULT_VERBOSITY))
+_cargo_silent_args_0 = --quiet
+_cargo_silent_args_1 = --verbose
+
+# Define the machinery to run for each crate
+# $(call call-cargo, crate, deps, features_arg)
+define call-cargo
+
+# Ensure we build all the deps first, then build our crate
+$(1): $(2)
+	$(_cargo_silent_prefix) $(CARGO) \
+	    build \
+	    $(CARGO_ARGS) \
+	    $(_cargo_silent_args) \
+	    $(3) \
+	    --manifest-path $(1)/Cargo.toml
+
+endef
+
+# Run CARGO on all the crates
+$(foreach crate, $(CARGO_CRATES), $(eval $(call call-cargo, $(crate), $($(crate)_DEPS), $(if $($(crate)_FEATURES), --features "$($(crate)_FEATURES)"))))
+
+# Ensure everything gets cleaned properly
+clean-local:
+	-rm -rf $(foreach crate, $(CARGO_CRATES), $(crate)/target)
+
+# Let cargo handle whether something needs rebuilding or not
+.PHONY: $(CARGO_CRATES)

--- a/configure.ac
+++ b/configure.ac
@@ -47,6 +47,8 @@ AM_PROG_CC_C_O
 
 AC_C_INLINE
 
+AX_REQUIRE_CARGO
+
 AC_CONFIG_FILES([
     Makefile
 ])
@@ -67,4 +69,6 @@ AC_MSG_RESULT([
     compiler:               ${CC}
     cflags:                 ${CFLAGS}
     ldflags:                ${LDFLAGS}
+
+    cargo:                  ${CARGO}
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ LT_LIB_M
 
 AX_PTHREAD
 
-AM_INIT_AUTOMAKE(automake_required [subdir-objects foreign no-dist-gzip dist-xz tar-ustar -Wall])
+AM_INIT_AUTOMAKE(automake_required [subdir-objects foreign no-dist-gzip dist-xz tar-ustar -Wall -Wno-portability])
 AM_MAINTAINER_MODE([enable])
 AM_SILENT_RULES([yes])
 

--- a/m4/.gitignore
+++ b/m4/.gitignore
@@ -1,2 +1,3 @@
 *.m4
 !ax_pthread.m4
+!ax_cargo.m4

--- a/m4/ax_cargo.m4
+++ b/m4/ax_cargo.m4
@@ -1,0 +1,12 @@
+dnl Copyright (c) 2016 Marc-Antoine Perennou <Marc-Antoine@Perennou.com>
+
+dnl AX_CARGO([value_if_not_found], [path])
+dnl Detect the presence of cargo and fill the CARGO variable with its value
+AC_DEFUN([AX_CARGO], [AC_CHECK_TOOL([CARGO], [cargo], [$1], [$2])])
+
+dnl AX_REQUIRE_CARGO([path])
+dnl Detect the presence of cargo and fill the CARGO variable with its value, fail if not found
+AC_DEFUN([AX_REQUIRE_CARGO], [
+    AX_CARGO([no], [$1])
+    AS_IF([test x${CARGO} = xno], [AC_MSG_ERROR([cargo is required])])
+])


### PR DESCRIPTION
I ended up integrating cargo and not rustc as it was both more easy and powerful imo.

Sample output of silent-mode compilation:

```
keruspe@Lou ~/Projects/nom_in_c (git)-[master] % make
make --no-print-directory all-am
  CC       src/main-main.o
  CARGO   embed
embed/src/lib.rs:18:5: 18:25 warning: unused import, #[warn(unused_imports)] on by default
embed/src/lib.rs:18 use std::prelude::v1::*;
                        ^~~~~~~~~~~~~~~~~~~~
  CARGO   embed_capi
embed/src/lib.rs:18:5: 18:25 warning: unused import, #[warn(unused_imports)] on by default
embed/src/lib.rs:18 use std::prelude::v1::*;
                        ^~~~~~~~~~~~~~~~~~~~
embed_capi/src/lib.rs:1:12: 1:18 warning: this feature is stable. attribute no longer needed, #[warn(stable_features)] on by default
embed_capi/src/lib.rs:1 #![feature(no_std,core)]
                                   ^~~~~~
embed_capi/src/lib.rs:1:19: 1:23 warning: unused or unknown feature, #[warn(unused_features)] on by default
embed_capi/src/lib.rs:1 #![feature(no_std,core)]
                                          ^~~~
embed_capi/src/lib.rs:4:5: 4:22 warning: unused import, #[warn(unused_imports)] on by default
embed_capi/src/lib.rs:4 use core::prelude::*;
                            ^~~~~~~~~~~~~~~~~
note: link against the following native artifacts when linking against this static library
note: the order and any duplication can be significant on some platforms, and so may need to be preserved
note: library: util
note: library: dl
note: library: pthread
note: library: gcc_s
note: library: c
note: library: m
note: library: rt
note: library: util
  CCLD     main
```
